### PR TITLE
Add route to get current user information

### DIFF
--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -692,4 +692,14 @@ router.delete(
   }
 );
 
+router.get('/current', authenticate(), async (req, res) => {
+  try {
+    res.type('application/json');
+    res.json(req.user);
+  } catch (error) {
+    log.error(error.message);
+    res.status(500).send(error.message);
+  }
+});
+
 export default router;

--- a/src/routes/user.test.js
+++ b/src/routes/user.test.js
@@ -142,4 +142,11 @@ describe('user route resource', () => {
       .get('/0')
       .expect(400, done);
   });
+
+  it('GET current user', done => {
+    request(app)
+      .get('/current')
+      .expect('Content-Type', /json/)
+      .expect(200, done);
+  });
 });


### PR DESCRIPTION
This PR adds a single GET route `/user/current` which returns the current user info as provided by the passport middleware.