### PR TITLE
Add ensureRole middleware

### DIFF
--- a/src/models/diluent.js
+++ b/src/models/diluent.js
@@ -34,7 +34,9 @@ module.exports = (sequelize, DataTypes) => {
   );
 
   Diluent.associate = function(models) {
-    this.hasMany(models.RecipesDiluents, {
+    this.belongsToMany(models.Recipe, {
+      as: 'Recipes',
+      through: models.RecipesDiluents,
       foreignKey: 'diluentId'
     });
   };

--- a/src/models/diluent.js
+++ b/src/models/diluent.js
@@ -37,7 +37,8 @@ module.exports = (sequelize, DataTypes) => {
     this.belongsToMany(models.Recipe, {
       as: 'Recipes',
       through: models.RecipesDiluents,
-      foreignKey: 'diluentId'
+      foreignKey: 'diluentId',
+      otherKey: 'recipeId'
     });
   };
   return Diluent;

--- a/src/models/flavor.js
+++ b/src/models/flavor.js
@@ -44,12 +44,14 @@ module.exports = (sequelize, DataTypes) => {
     this.belongsToMany(models.Recipe, {
       as: 'Recipes',
       through: models.RecipesFlavors,
-      foreignKey: 'flavorId'
+      foreignKey: 'flavorId',
+      otherKey: 'recipeId'
     });
     this.belongsToMany(models.User, {
       as: 'Owners',
       through: models.UsersFlavors,
-      foreignKey: 'flavorId'
+      foreignKey: 'flavorId',
+      otherKey: 'userId'
     });
   };
 

--- a/src/models/flavor.js
+++ b/src/models/flavor.js
@@ -41,8 +41,16 @@ module.exports = (sequelize, DataTypes) => {
   Flavor.associate = function(models) {
     this.belongsTo(models.Vendor, { foreignKey: 'vendorId' });
     this.hasMany(models.FlavorIdentifier, { foreignKey: 'flavorId' });
-    this.hasMany(models.RecipesFlavors, { foreignKey: 'flavorId' });
-    this.hasMany(models.UsersFlavors, { foreignKey: 'flavorId' });
+    this.belongsToMany(models.Recipe, {
+      as: 'Recipes',
+      through: models.RecipesFlavors,
+      foreignKey: 'flavorId'
+    });
+    this.belongsToMany(models.User, {
+      as: 'Owners',
+      through: models.UsersFlavors,
+      foreignKey: 'flavorId'
+    });
   };
 
   return Flavor;

--- a/src/models/preparation.js
+++ b/src/models/preparation.js
@@ -61,7 +61,8 @@ module.exports = (sequelize, DataTypes) => {
     this.belongsToMany(models.Diluent, {
       as: 'Diluents',
       through: models.PreparationsDiluents,
-      foreignKey: 'preparationId'
+      foreignKey: 'preparationId',
+      otherKey: 'diluentId'
     });
   };
 

--- a/src/models/preparation.js
+++ b/src/models/preparation.js
@@ -58,7 +58,11 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       sourceKey: 'userId'
     });
-    this.hasMany(models.PreparationsDiluents, { foreignKey: 'preparationId' });
+    this.belongsToMany(models.Diluent, {
+      as: 'Diluents',
+      through: models.PreparationsDiluents,
+      foreignKey: 'preparationId'
+    });
   };
 
   return Preparation;

--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -52,12 +52,14 @@ module.exports = (sequelize, DataTypes) => {
     this.belongsToMany(models.Flavor, {
       as: 'Flavors',
       through: models.RecipesFlavors,
-      foreignKey: 'recipeId'
+      foreignKey: 'recipeId',
+      otherKey: 'flavorId'
     });
     this.belongsToMany(models.Diluent, {
       as: 'Diluents',
       through: models.RecipesDiluents,
-      foreignKey: 'recipeId'
+      foreignKey: 'recipeId',
+      otherKey: 'diluentId'
     });
     this.hasMany(models.Preparation, {
       foreignKey: 'recipeId'

--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -49,10 +49,14 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       sourceKey: 'userId'
     });
-    this.hasMany(models.RecipesFlavors, {
+    this.belongsToMany(models.Flavor, {
+      as: 'Flavors',
+      through: models.RecipesFlavors,
       foreignKey: 'recipeId'
     });
-    this.hasMany(models.RecipesDiluents, {
+    this.belongsToMany(models.Diluent, {
+      as: 'Diluents',
+      through: models.RecipesDiluents,
       foreignKey: 'recipeId'
     });
     this.hasMany(models.Preparation, {

--- a/src/models/role.js
+++ b/src/models/role.js
@@ -22,8 +22,13 @@ module.exports = (sequelize, DataTypes) => {
     }
   );
 
-  Role.associate = function() {
-    //
+  Role.associate = function(models) {
+    this.belongsToMany(models.User, {
+      as: 'Users',
+      through: models.UsersRoles,
+      foreignKey: 'roleId',
+      otherKey: 'userId'
+    });
   };
 
   return Role;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -45,11 +45,17 @@ module.exports = (sequelize, DataTypes) => {
     this.hasMany(models.Preparation, {
       foreignKey: 'userId'
     });
-    this.hasMany(models.UsersFlavors, {
-      foreignKey: 'userId'
+    this.belongsToMany(models.Flavor, {
+      as: 'Flavors',
+      through: models.UsersFlavors,
+      foreignKey: 'userId',
+      otherKey: 'flavorId'
     });
-    this.hasMany(models.UsersRoles, {
-      foreignKey: 'userId'
+    this.belongsToMany(models.Role, {
+      as: 'Roles',
+      through: models.UsersRoles,
+      foreignKey: 'userId',
+      otherKey: 'roleId'
     });
     this.hasMany(models.UserToken, {
       foreignKey: 'userId'

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -168,8 +168,7 @@ export const ensureRole = name => async (req, res, next) => {
       throw new Error('User lacks required role!');
     }
 
-    res.type('application/json');
-    res.send(role);
+    next(null);
   } catch (error) {
     next(error);
   }

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -11,6 +11,7 @@ import { compareHashAndPassword, generateToken } from './util';
 
 const log = loggers('auth');
 const { UserToken, User } = models;
+const { Op } = models.Sequelize;
 
 const { api: webConfig } = configs;
 const { age: tokenAge, validate: validateTokens } = webConfig.tokens;
@@ -25,7 +26,10 @@ const authorize = async (token, done) => {
 
     const result = await UserToken.findAll({
       where: {
-        token
+        token,
+        expires: {
+          [Op.gt]: Date.now()
+        }
       },
       include: [
         {

--- a/src/routes/data.js
+++ b/src/routes/data.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param, validationResult } from 'express-validator';
 
-import { authenticate } from '../modules/auth';
+import { authenticate, ensureRole } from '../modules/auth';
 import models from '../modules/database';
 import loggers from '../modules/logging';
 
@@ -219,27 +219,32 @@ router.get('/suppliers', authenticate(), async (req, res) => {
 /**
  * GET Database Schema Version Info
  */
-router.get('/version', authenticate(), async (req, res) => {
-  const errors = validationResult(req);
+router.get(
+  '/version',
+  authenticate(),
+  ensureRole('Administrator'),
+  async (req, res) => {
+    const errors = validationResult(req);
 
-  if (!errors.isEmpty()) {
-    return res.status(400).json({ errors: errors.array() });
-  }
-
-  log.info(`request for Schema Version`);
-  try {
-    const result = await SchemaVersion.findAll();
-
-    if (!result || result.length === 0) {
-      return res.status(204).end();
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
 
-    res.type('application/json');
-    res.json(result);
-  } catch (error) {
-    log.error(error.message);
-    res.status(500).send(error.message);
+    log.info(`request for Schema Version`);
+    try {
+      const result = await SchemaVersion.findAll();
+
+      if (!result || result.length === 0) {
+        return res.status(204).end();
+      }
+
+      res.type('application/json');
+      res.json(result);
+    } catch (error) {
+      log.error(error.message);
+      res.status(500).send(error.message);
+    }
   }
-});
+);
 
 export default router;


### PR DESCRIPTION
This PR makes the following changes:

* [Converts](https://github.com/daviddyess/api/compare/feature/routes...ayan4m1:feature/role-auth?expand=1#diff-30857314e1156a6fd894d9ce3a948cd0R37) all `hasMany` associations on xref tables to `belongsToMany` - [sequelize docs](https://sequelize.org/master/manual/associations.html#belongs-to-many-associations)
* [Fix](https://github.com/daviddyess/api/compare/feature/routes...ayan4m1:feature/role-auth?expand=1#diff-0c9614a084d6e4ba1ccd77842a359e7eR31) a security issue where token expiration was not being validated
* [Add](https://github.com/daviddyess/api/compare/feature/routes...ayan4m1:feature/role-auth?expand=1#diff-0c9614a084d6e4ba1ccd77842a359e7eR141) a middleware funtion `ensureRole(name)` which will return an HTTP 401 if the user does not have the role specified in the `name` parameters
* [Add](https://github.com/daviddyess/api/compare/feature/routes...ayan4m1:feature/role-auth?expand=1#diff-231fd2b9e2ed7f0b655701a3ac9fe9a6R225) ensureRole to `/data/version` GET requests